### PR TITLE
Read-only constraints

### DIFF
--- a/lib/constraint.js
+++ b/lib/constraint.js
@@ -55,7 +55,8 @@ const DETACHED = Symbol("detached");
 const bothNaN = (a, b) => isNaN(a) && isNaN(b) && typeof a === "number" && typeof b === "number";
 
 const DEFAULT_SETTINGS = {
-    equals: (a, b) => a === b || bothNaN(a, b)
+    equals: (a, b) => a === b || bothNaN(a, b),
+    detachable: true
 }
 
 /*
@@ -71,6 +72,11 @@ export default class Constraint {
      */
     constructor (getter, settings) {
         this._settings = Object.assign({}, DEFAULT_SETTINGS, settings);
+        // default read-only depends of the provided getter
+        if(this._settings.readOnly == null){
+            this._settings.readOnly = typeof getter === 'function'
+                                    || getter instanceof Constraint;
+        }
         this._getter = null;
         this._value = null;
         this._state = INVALID;
@@ -79,7 +85,7 @@ export default class Constraint {
         // Registers handlers to be called when the constraint may have changed.
         // Contains an object (see onMayHaveChanged).
         this._mayHaveChangedListeners = [];
-        this.set(getter);
+        this._set(getter);
     }
 
     /*
@@ -87,8 +93,19 @@ export default class Constraint {
      * If it is a function, this function will be used as a getter.
      * If it is another constraint, this constraint will be constrained
      * to this other constraint.
+     * If it is any other value, the constraint will be set to this value.
+     *
+     * Read-only constraints can only be set while created.
      */
-    set(getter) {
+    set(getter){
+        if(this.readOnly){
+            // TODO: use a real exception instead of a string.
+            throw "Cannot set a read-only constraint."
+        }
+        this._set(getter);
+    }
+
+    _set(getter){
         this._getter = Constraint._createGetter(getter);
         this.invalidate();
     }
@@ -329,6 +346,10 @@ export default class Constraint {
      * Once the constraint is detached, its behavior is not guaranteed.
      */
     detach(){
+        if(!this.detachable){
+            // TODO: use a real exception instead of a string.
+            throw "This constraint is not detachable.";
+        }
         // Clear dependencies.
         this._dependencies.forEach(
             (d) => d._dependentConstraints.delete(this)
@@ -351,6 +372,18 @@ export default class Constraint {
         } else {
             return () => getter;
         }
+    }
+
+    get readOnly(){
+        return !!this._settings.readOnly;
+    }
+
+    get detachable(){
+        return !!this._settings.detachable;
+    }
+
+    view(){
+        return new Constraint(this, { readOnly: true, detachable: false });
     }
 
     alter (f){

--- a/tests/base.js
+++ b/tests/base.js
@@ -24,7 +24,7 @@ test("Constraint ties", (assert) => {
 test("Constraint set to constraint", (assert) => {
     var x = tie('x');
     var y = tie('y');
-    var z = tie(x);
+    var z = tie(x, { readOnly: false });
 
     assert.equal(z.get(), 'x',
         "Constraint set to a constraint get its value."

--- a/tests/settings.js
+++ b/tests/settings.js
@@ -34,3 +34,119 @@ test("Equals setting", (assert) => {
     assert.end();
 });
 
+test("Read-Only", (assert) => {
+    const src = tie("value");
+    const roc = tie(src, { readOnly: true });
+    assert.equals(roc.get(), "value",
+        "Read-only constraints get the proper value.");
+    assert.throws(() => roc.set(8),
+        "Read-only constraints cannot be set.");
+    src.set("other value");
+    assert.equals(roc.get(), "other value",
+        "Read-only constraints are properly updated.");
+    assert.notOk(src.readOnly,
+        "readOnly getter is false for writable constraints.");
+    assert.ok(roc.readOnly,
+        "readOnly getter is true for read-only constraints.");
+    assert.end();
+});
+
+test("Undetachable", (assert) => {
+    const src = tie("value");
+    const udc = tie(src, { detachable: false });
+    assert.equals(udc.get(), "value",
+        "Undetachable constraints get the proper value.");
+    assert.throws(() => udc.detach(),
+        "Undetachable constraints cannot be detached.");
+    assert.ok(src.detachable,
+        "Per default, constraint are detachable and their detachable getter is true.");
+    assert.notOk(udc.detachable,
+        "detachable getter is false for undetachable constraints.");
+    src.detach();
+    assert.equals(src.get(), void(0),
+        "Per default, constraint can be detached");
+    assert.end();
+});
+
+test("View", (assert) => {
+    const src = tie("value");
+    const view = src.view();
+    assert.equals(view.get(), "value",
+        "Views get their source's value.");
+    assert.ok(view.readOnly,
+        "View's read-only getter is properly set.");
+    assert.notOk(view.detachable,
+        "View's detachable getter is properly set.");
+    assert.throws(() => view.set(8),
+        "Views cannot be set.");
+    assert.throws(() => view.detach(),
+        "Views cannot be detached.");
+    assert.end();
+});
+
+test("Default for constraint set to a function", (assert) => {
+    const funcConstraint = tie(() => 6);
+    assert.ok(funcConstraint.readOnly,
+        "Constraints set to a function are read-only per default.");
+    assert.throws(() => funcConstraint.set(9),
+        "They cannot be set (per default).");
+    const settableFuncConstraint = tie(() => 9, { readOnly: false });
+    assert.notOk(settableFuncConstraint.readOnly,
+        "It is possible to overwrite the default read-only settings.");
+    settableFuncConstraint.set(10);
+    assert.equals(settableFuncConstraint.get(), 10,
+        "So that a constraint set to a function can be overwriten.");
+    assert.end();
+});
+
+test("Default for constraint set to another constraint", (assert) => {
+    const src = tie(8);
+    const consCons = tie(src);
+    assert.ok(consCons.readOnly,
+        "Constraints set to a function are read-only per default.");
+    assert.throws(() => consCons.set(9),
+        "They cannot be set (per default).");
+    const settableConsCons = tie(() => 9, { readOnly: false });
+    assert.notOk(settableConsCons.readOnly,
+        "It is possible to overwrite the default read-only settings.");
+    settableConsCons.set(10);
+    assert.equals(settableConsCons.get(), 10,
+        "So that a constraint set to a function can be overwriten.");
+    assert.end();
+});
+
+test("Default for constraint set to anything else", (assert) => {
+    const strConstraint = tie("value");
+    assert.notOk(strConstraint.readOnly,
+        "Constraints set to a string, an object, a number or null are writable per default.");
+    assert.doesNotThrow(() => strConstraint.set("value"),
+        "They can be overwriten (per default).");
+    assert.equals(strConstraint.get(), "value",
+        "And will get the newly set value.");
+
+    const objConstraint = tie({prop:"prop"});
+    assert.notOk(objConstraint.readOnly,
+        "Constraints set to a string, an object, a number or null are writable per default.");
+    assert.doesNotThrow(() => objConstraint.set("value"),
+        "They can be overwriten (per default).");
+    assert.equals(objConstraint.get(), "value",
+        "And will get the newly set value.");
+
+    const numberConstraint = tie(10);
+    assert.notOk(numberConstraint.readOnly,
+        "Constraints set to a string, an object, a number or null are writable per default.");
+    assert.doesNotThrow(() => numberConstraint.set("value"),
+        "They can be overwriten (per default).");
+    assert.equals(numberConstraint.get(), "value",
+        "And will get the newly set value.");
+
+    const nullConstraint = tie(null);
+    assert.notOk(nullConstraint.readOnly,
+        "Constraints set to a string, an object, a number or null are writable per default.");
+    assert.doesNotThrow(() => nullConstraint.set("value"),
+        "They can be overwriten (per default).");
+    assert.equals(nullConstraint.get(), "value",
+        "And will get the newly set value.");
+
+    assert.end();
+});


### PR DESCRIPTION
Protecting an internal constraint is I guess quite easy: one only have to provide a 'public' constraint on its 'private' constraint instead of the 'private' constraint itself. But the setter of this public constraint is still callable and one may still re-set it.

At the opposite, a view on the 'private' constraint would be only get-able. The idea is that it reacts and can be used exactly as any other constraint. It would of course still be invalidated by its parent constraint... But one cannot change directly its value.
Also it should not be detachable.

Thus, one could expose a bunch of protected constraints as an interface.